### PR TITLE
update npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "mdcodes",
-  "version": "2.8.2",
+  "version": "2.8.4",
   "main": "index.js",
   "description": "CodeLists for ADIwg mdJSON",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adiwg/mdCodes.git"
+    "url": "git+https://github.com/adiwg/mdCodes.git"
   },
   "keywords": [
     "metadata",
@@ -28,8 +28,12 @@
     "prepublishOnly": "scripts/prepublish.js"
   },
   "dependencies": {
-    "buildify": "powmedia/buildify#20458a121411f759dcc5ec1b441695eb7fc2b3b7",
+    "buildify": "github:powmedia/buildify#20458a121411f759dcc5ec1b441695eb7fc2b3b7",
     "glob": "^7.1.0",
     "rimraf": "^2.6.2"
+  },
+  "directories": {
+    "lib": "lib",
+    "test": "test"
   }
 }

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -7,9 +7,13 @@ let buildify = require('buildify');
 let rimraf = require('rimraf');
 let path = 'resources/js';
 
-if (fs.statSync(path).isDirectory()) {
+console.log('Start Preprocess for npm publishing')
+
+if (fs.existsSync(path)) {
   rimraf.sync(path);
-  console.log('Removed existing resources/js files.');
+  console.log('Removed existing resources/js files');
+} else {
+  console.log('No existing resources/js files');
 }
 
 fs.mkdirSync(path);


### PR DESCRIPTION
Bumped npmjs version to 2.8.4 and updated the pre-publish script. There was an uncaught error if resources/js didn't exist.

Steps to publish to npmjs (note: use --force to get past dependency issues).
```
npm install --force
npm init
npm adduser
npm publish --access public
```
```
node version 16.20.0
npm version 8.19.4
```
https://www.npmjs.com/package/mdcodes?activeTab=versions
