### PR TITLE
fix typo in codeName

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdcodes",
-  "version": "2.9.2",
+  "version": "2.9.3-beta.0",
   "main": "index.js",
   "description": "CodeLists for ADIwg mdJSON",
   "repository": {

--- a/resources/iso_geometryTypeCode.yml
+++ b/resources/iso_geometryTypeCode.yml
@@ -12,4 +12,4 @@ codelist:
   - {code: "001", codeName: point, description: "single geographic point of interest"}
   - {code: "002", codeName: linear, description: "extended collection in a single vector"}
   - {code: "003", codeName: areal, description: "collection of a geographic area defined by a polygon (coverage)"}
-  - {code: "004", codeName: stripe, description: "series of linear collections grouped by way points"}
+  - {code: "004", codeName: strip, description: "series of linear collections grouped by way points"}


### PR DESCRIPTION
Closes #72 

# Changes

Version 2.9.3-beta.0

## Fixed Typo

Fixed a typo in the MI_GeometryTypeCode list

stripe -> strip