### PR TITLE
fix code list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdcodes",
-  "version": "2.9.2",
+  "version": "2.9.3-beta.1",
   "main": "index.js",
   "description": "CodeLists for ADIwg mdJSON",
   "repository": {

--- a/resources/iso_operationTypeCode.yml
+++ b/resources/iso_operationTypeCode.yml
@@ -9,6 +9,6 @@ sourceName: "MI_OperationTypeCode"
 extensible: true
 description: "code indicating whether the data contained in this packet is real (originates from live-fly or other non-simulated operational sources), simulated (originates from target simulator sources), or synthesized (a mix of real and simulated data)."
 codelist:
-  - {code: "001", codeName: instantaneousCollection, description: "originates from live-fly or other non-simulated operational source"}
-  - {code: "002", codeName: persistentView, description: "originates from target simulator sources"}
-  - {code: "003", codeName: survey, description: "mix of real and simulated data"}
+  - {code: "001", codeName: real, description: "originates from live-fly or other non-simulated operational source"}
+  - {code: "002", codeName: simulated, description: "originates from target simulator sources"}
+  - {code: "003", codeName: synthetic, description: "mix of real and simulated data"}


### PR DESCRIPTION
Closes #73 

# Changes

Version 2.9.3-beta.1

## Operation Type Code

MI_OperationTypeCode fixed to use correct list

- real
- simulated
- synthetic

### Notes

MI_OperationTypeCode looks like it might have been updated with the 2023 revision. ["synthesized"](https://wiki.esipfed.org/ISO_19115-3_Codelists#MI_OperationTypeCode) appears to have been changed to ["synthetic"](https://standards.iso.org/iso/19115/resources/Codelists/gml/MI_OperationTypeCode.xml)

MI_ObjectiveTypeCode and MI_OperationTypeCode have been jumbled. Both lists were the same, but the codes and the descriptions were from the opposite lists, so neither one is fully correct. Another issue will be added to fix MI_ObjectiveTypeCode descriptions.