### PR TITLE
Add bureauCode and programCode to adiwg_namespace

### DIFF
--- a/resources/adiwg_namespace.yml
+++ b/resources/adiwg_namespace.yml
@@ -23,3 +23,5 @@ codelist:
   - {code: "spatialreference.org", codeName: SR-ORG, description: "Coordinate reference system from SpatialReference.org database"}
   - {code: "org.adiwg.code.mapGridSystem", codeName: mapGridSystem, description: "Name of the grid UTM, State Plane, or other grid system used by a spatial reference system."}
   - {code: "org.adiwg.code.mapProjection", codeName: mapProjection, description: "Name of the planar, grid, or local projection used by a spatial reference system."}
+  - {code: "org.adiwg.code.bureauCode", codeName: bureauCode, description: "DCAT-US combined federal agency and bureau code from OMB Circular A-11."}
+  - {code: "org.adiwg.code.programCode", codeName: programCode, description: "DCAT-US Federal Program Inventory program code."} 


### PR DESCRIPTION
## Changes
- Adds two new codes to `adiwg_namespace.yml`: bureauCode and programCode. This will be used for support within DCAT-US