### PR TITLE
Add GitHub Actions workflow for automated release creation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+
+      - name: Create Tag
+        id: create_tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Read version from package.json
+          version=$(node -p "require('./package.json').version")
+          version_tag="v$version"
+          echo "Version from package.json: $version_tag"
+          echo "version=$version_tag" >> $GITHUB_OUTPUT
+          git tag $version_tag
+          git push origin $version_tag
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.create_tag.outputs.version }}
+          name: Release ${{ steps.create_tag.outputs.version }}
+          body: Automated release for version ${{ steps.create_tag.outputs.version }}.
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #96 

## Testing

This cannot be tested without merging this PR. In order to test this action, this PR must be merged and a new PR opened and merged to push these changes into the master branch. Merging a PR into the master branch is how this action can be tested.

That being said, I have tested this by forking to [jwaspin/mdCodes](https://github.com/jwaspin/mdCodes) and [this shows the action completed successfully](https://github.com/jwaspin/mdCodes/actions/runs/12035486633).

## Changes

Automatically create and tag a release version based on the version in package.json.

### Current

Nothing happens when a branch is merged into master.

### New

When a branch is merged into master a release version will be created and tagged with the version number in package.json and it will be set as the latest release.

